### PR TITLE
fix: anchor relative includes to __DIR__ (issue #47)

### DIFF
--- a/easyBackendStyle.php
+++ b/easyBackendStyle.php
@@ -35,7 +35,7 @@ use Farn\EasyBackendStyle\Type;
 
 //------------------------------------------Plugin Code--------------------------------------------
 
-include_once "vendor/autoload.php";
+include_once __DIR__ . "/vendor/autoload.php";
 
 
 add_action( 'init', function (){
@@ -153,7 +153,7 @@ class easyBackendStyle {
      */
     function settings_page(): void
     {
-        include_once('src/ebs_SettingsSubMenu.php');
+        include_once(__DIR__ . '/src/ebs_SettingsSubMenu.php');
     }
 
     //In class function that calls the getValueFromDB() function from the DatabaseConnector.

--- a/src/deprecated/easyBackendStyle_deprecated.php
+++ b/src/deprecated/easyBackendStyle_deprecated.php
@@ -76,7 +76,7 @@ class easyBackendStyle_deprecated
      */
     function settings_page(): void
     {
-        include_once('ebs_SettingsSubMenu.php');
+        include_once(__DIR__ . '/ebs_SettingsSubMenu.php');
     }
 
     //In class function that calls the getValueFromDB() function from the DatabaseConnector.


### PR DESCRIPTION
The plugin used path-relative include_once for vendor/autoload.php and src/ebs_SettingsSubMenu.php, which PHP resolves against the current working directory rather than the plugin file's directory.

When WordPress is bootstrapped from a script located outside the WP root (e.g. a custom plugin template that loads wp-load.php directly), getcwd() is not the WP root, so the autoloader is not found and every namespaced class referenced by the plugin fails to load with a fatal error.

Anchoring both includes to __DIR__ makes them independent of the caller's working directory.

Fixes #47